### PR TITLE
Adding 4 different unwinders with unit tests and benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,57 @@
+# Travis-CI for Iknaia
+
+language: cpp
+
+sudo: required
+
+# Compiler selection
+compiler:
+  - gcc
+
+# Before Installing
+before_install:
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update; fi
+
+# Install dependencies
+install:
+  # Installing gcc-4.7
+  - if [ "$CXX" = "g++" ]; then sudo apt-get -y install g++-4.7; fi
+  - if [ "$CXX" = "g++" ]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 90; fi
+  # Install libunwind
+  - sudo apt-get install -y libunwind7-dev
+  # Install Google Test
+  - pushd .
+  - wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+  - tar xvf release-1.8.0.tar.gz
+  - cd googletest-release-1.8.0
+  - mkdir build ; cd build
+  - cmake .. && make -j4
+  - sudo make install
+  - popd
+  # Install Google Benchmark
+  - pushd .
+  - wget https://github.com/lorenzodavid/benchmark/archive/1.1.0.tar.gz
+  - tar xvf 1.1.0.tar.gz
+  - cd benchmark-1.1.0
+  - wget https://gist.githubusercontent.com/lorenzodavid/76d368f50f53dc219cfe06562a4603be/raw/7da3a41962c8d38a29c69f017c216ae9b76ab76b/benchmark.patch
+  - patch -p1 < benchmark.patch
+  - mkdir build ; cd build
+  - cmake .. && make -j4
+  - sudo make install
+  - popd
+  # Install Coumap
+  - pushd .
+  - wget https://github.com/lorenzodavid/coumap/archive/0.0.1.tar.gz
+  - tar xvf 0.0.1.tar.gz
+  - cd coumap-0.0.1
+  - mkdir build ; cd build
+  - cmake .. && make -j4
+  - sudo make install
+  - popd
+
+# Build steps
+script:
+  - mkdir build
+  - cd build
+  - cmake .. && make
+  - ctest -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.8)
+project(unwind)
+cmake_policy(VERSION 2.8.7)
+
+INCLUDE(CMakeForceCompiler)
+CMAKE_FORCE_C_COMPILER(gcc GNU)
+CMAKE_FORCE_CXX_COMPILER(g++ GNU)
+
+set(CMAKE_CXX_FLAGS "-std=c++11")
+
+add_definitions(-Werror)
+
+enable_testing()
+
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+include_directories (${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# List of all subdirectories in the unwind project
+#
+list(APPEND UNWIND_SUBDIRS src test benchmark)
+
+foreach(dir ${UNWIND_SUBDIRS})
+  add_subdirectory(${dir})
+  file(GLOB_RECURSE C_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.c)
+  file(GLOB_RECURSE CC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.cc)
+  file(GLOB_RECURSE H_FILES ${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.h)
+  list(APPEND CPPLINT_C_FILES ${C_FILES})
+  list(APPEND CPPLINT_CC_FILES ${CC_FILES})
+  list(APPEND CPPLINT_H_FILES ${H_FILES})
+endforeach()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,14 @@
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(bm_libunwind bm_libunwind.cc bm_common.cc)
+target_link_libraries(bm_libunwind runtime_callers benchmark pthread)
+
+add_executable(bm_backtrace bm_backtrace.cc bm_common.cc)
+target_link_libraries(bm_backtrace runtime_callers benchmark pthread)
+
+add_executable(bm_frameptr bm_frameptr.cc bm_common.cc)
+target_link_libraries(bm_frameptr runtime_callers benchmark pthread)
+set_target_properties(bm_frameptr PROPERTIES COMPILE_FLAGS "-fno-omit-frame-pointer")
+
+add_executable(bm_tracewinder bm_tracewinder.cc bm_common.cc)
+target_link_libraries(bm_tracewinder runtime_callers benchmark pthread)

--- a/benchmark/bm_backtrace.cc
+++ b/benchmark/bm_backtrace.cc
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include "benchmark/bm_common.h"
+
+#include "benchmark/benchmark.h"
+
+static char doc[] =
+  "Benchmark backtrace unwinder.\n"
+  "\n"
+  "BM_T01      : same stack trace\n"
+  "BM_T02      : different stack traces\n"
+  "BM_T03      : randomized\n"
+  "\n"
+  "The test invokes the unwinder function in a loop.\n"
+  "The number of loop iterations are follows the test name.\n"
+  "\n";
+
+static void BM_T01(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_backtrace);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < ITERATION; i++) {
+      l1_1();
+    }
+  }
+}
+
+BENCHMARK(BM_T01)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T02(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_backtrace);
+  while (state.KeepRunning()) {
+    faux_unroll<ITERATION>::call([&] {
+        l1_1();
+      });
+  }
+}
+
+BENCHMARK(BM_T02)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T03(benchmark::State& state) { //NOLINT
+  unsigned int seed = time(NULL);
+  set_runtime_pcs(runtime_pcs_backtrace);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < state.range(0); i++) {
+      call_m(rand_r(&seed) % 1);
+    }
+  }
+}
+
+BENCHMARK(BM_T03)
+->Arg(10*ITERATION)
+->Arg(100*ITERATION)
+->Arg(1000*ITERATION)
+->Arg(10000*ITERATION)
+->Unit(benchmark::kMillisecond);
+
+int main(int argc, char **argv) {
+  printf("Running %s\n", argv[0]);
+
+  printf("%s", doc);
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/benchmark/bm_common.cc
+++ b/benchmark/bm_common.cc
@@ -1,0 +1,498 @@
+#include "bm_common.h"
+
+// Global
+Tracewinder *tracewinder;
+bool use_tracewinder = false;
+
+runtime_pcs current_runtime_pcs = runtime_pcs_libunwind;
+
+void set_runtime_pcs(runtime_pcs new_runtime_pcs) {
+  current_runtime_pcs = new_runtime_pcs;
+  use_tracewinder = false;
+}
+
+void set_runtime_pcs(Tracewinder *p) {
+  tracewinder = p;
+  use_tracewinder = true;
+}
+
+int get_current_runtime_pcs(uintptr *pcbuf, int buffers) {
+  if (use_tracewinder) {
+    return tracewinder->runtime_pcs_tracewinder(pcbuf, buffers);
+  } else {
+    return current_runtime_pcs(pcbuf, buffers);
+  }
+}
+
+// Layer 1
+void l1_7() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+
+void l1_6() {
+  l1_7();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+void l1_5() {
+  l1_6();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+void l1_4() {
+  l1_5();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+void l1_3() {
+  l1_4();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+void l1_2() {
+  l1_3();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+void l1_1() {
+  l1_2();
+  // avoid tail call optimizations
+  asm volatile("mfence" : : : "memory");
+}
+
+
+void f1() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f2() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f3() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f4() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f5() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f6() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f7() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f8() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f9() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f10() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f11() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f12() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f13() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f14() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f15() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f16() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f17() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f18() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f19() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f20() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f21() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f22() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f23() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f24() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f25() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f26() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f27() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f28() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f29() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f30() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f31() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f32() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f33() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f34() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f35() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f36() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f37() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f38() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f39() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f40() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f41() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f42() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f43() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f44() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f45() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f46() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f47() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f48() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f49() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f50() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f51() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f52() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f53() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f54() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f55() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f56() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f57() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f58() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f59() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f60() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f61() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f62() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f63() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f64() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f65() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f66() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f67() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f68() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f69() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f70() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f71() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f72() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f73() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f74() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f75() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f76() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f77() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f78() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f79() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f80() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f81() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f82() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f83() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f84() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f85() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f86() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f87() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f88() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f89() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f90() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f91() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f92() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f93() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f94() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f95() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f96() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f97() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f98() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f99() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+void f100() {
+  uintptr pcbuf[100];
+  get_current_runtime_pcs(pcbuf, sizeof pcbuf / sizeof pcbuf[0]);
+}
+
+typedef void (*f)();
+
+f m[100] = {
+  f1, f2, f3, f4, f5,
+  f6, f7, f8, f9, f10,
+  f11, f12, f13, f14, f15,
+  f16, f17, f18, f19, f20,
+  f21, f22, f23, f24, f25,
+  f26, f27, f28, f29, f30,
+  f31, f32, f33, f34, f35,
+  f36, f37, f38, f39, f40,
+  f41, f42, f43, f44, f45,
+  f46, f47, f48, f49, f50,
+  f51, f52, f53, f54, f55,
+  f56, f57, f58, f59, f60,
+  f61, f62, f63, f64, f65,
+  f66, f67, f68, f69, f70,
+  f71, f72, f73, f74, f75,
+  f76, f77, f78, f79, f80,
+  f81, f82, f83, f84, f85,
+  f86, f87, f88, f89, f90,
+  f91, f92, f93, f94, f95,
+  f96, f97, f98, f99, f100
+};
+
+void call_m(int idx) {
+  m[idx]();
+}

--- a/benchmark/bm_common.h
+++ b/benchmark/bm_common.h
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include "common.h"
+#include "runtime_callers.h" // for current_runtime_pcs initialization
+
+#pragma once
+
+#define NOINLINE       __attribute__((noinline))
+
+typedef int (*runtime_pcs)(uintptr *, int);
+
+#define ITERATION 800
+
+void set_runtime_pcs(runtime_pcs new_runtime_pcs);
+void set_runtime_pcs(Tracewinder *p);
+
+void l1_1();
+void call_m(int idx);
+
+template <unsigned N> struct faux_unroll {
+  template <typename F> static void call(F const& f) {
+    f();
+    faux_unroll<N-1>::call(f);
+  }
+};
+
+template <> struct faux_unroll<0u> {
+  template <typename F> static void call(F const& f) {
+    f();
+  }
+};

--- a/benchmark/bm_frameptr.cc
+++ b/benchmark/bm_frameptr.cc
@@ -1,0 +1,64 @@
+#include <stdio.h>
+#include "benchmark/bm_common.h"
+
+#include "benchmark/benchmark.h"
+
+static char doc[] =
+  "Benchmark stack unwinding with frame pointers.\n"
+  "\n"
+  "BM_T01      : same stack trace\n"
+  "BM_T02      : different stack traces\n"
+  "BM_T03      : randomized\n"
+  "\n"
+  "The test invokes the unwinder function in a loop.\n"
+  "The number of loop iterations are follows the test name.\n"
+  "\n";
+
+static void BM_T01(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_frameptr);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < ITERATION; i++) {
+      l1_1();
+    }
+  }
+}
+
+BENCHMARK(BM_T01)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T02(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_frameptr);
+  while (state.KeepRunning()) {
+    faux_unroll<ITERATION>::call([&] {
+        l1_1();
+      });
+  }
+}
+
+BENCHMARK(BM_T02)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T03(benchmark::State& state) { //NOLINT
+  unsigned int seed = time(NULL);
+  set_runtime_pcs(runtime_pcs_frameptr);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < state.range(0); i++) {
+      call_m(rand_r(&seed) % 1);
+    }
+  }
+}
+
+BENCHMARK(BM_T03)
+->Arg(10*ITERATION)
+->Arg(100*ITERATION)
+->Arg(1000*ITERATION)
+->Arg(10000*ITERATION)
+->Unit(benchmark::kMillisecond);
+
+int main(int argc, char **argv) {
+  printf("Running %s\n", argv[0]);
+
+  printf("%s", doc);
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/benchmark/bm_libunwind.cc
+++ b/benchmark/bm_libunwind.cc
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include "benchmark/bm_common.h"
+
+#include "benchmark/benchmark.h"
+
+static char doc[] =
+  "Benchmark tracewinder.\n"
+  "The benchmark shows results for uncached libunwind\n"
+  "and cached-enabled libunwind.\n"
+  "\n"
+  "BM_T01      : same stack trace\n"
+  "BM_T02      : different stack traces\n"
+  "BM_T03      : randomized\n"
+  "\n"
+  "The test invokes the unwinder function in a loop.\n"
+  "The number of loop iterations are follows the test name.\n"
+  "\n";
+
+static void BM_T01_cached(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_libunwind_builtin_cache);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < ITERATION; i++) {
+      l1_1();
+    }
+  }
+  flush_libunwind_builtin_cache();
+}
+
+BENCHMARK(BM_T01_cached)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T02_cached(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_libunwind_builtin_cache);
+  while (state.KeepRunning()) {
+    faux_unroll<ITERATION>::call([&] {
+        l1_1();
+      });
+  }
+  flush_libunwind_builtin_cache();
+}
+
+BENCHMARK(BM_T02_cached)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T03_cached(benchmark::State& state) { //NOLINT
+  unsigned int seed = time(NULL);
+  set_runtime_pcs(runtime_pcs_libunwind_builtin_cache);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < state.range(0); i++) {
+      call_m(rand_r(&seed) % 1);
+    }
+  }
+  flush_libunwind_builtin_cache();
+}
+
+BENCHMARK(BM_T03_cached)
+->Arg(10*ITERATION)
+->Arg(100*ITERATION)
+->Arg(1000*ITERATION)
+->Arg(10000*ITERATION)
+->Unit(benchmark::kMillisecond);
+
+static void BM_T01_uncached(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_libunwind);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < ITERATION; i++) {
+      l1_1();
+    }
+  }
+}
+
+BENCHMARK(BM_T01_uncached)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T02_uncached(benchmark::State& state) { //NOLINT
+  set_runtime_pcs(runtime_pcs_libunwind);
+  while (state.KeepRunning()) {
+    faux_unroll<ITERATION>::call([&] {
+        l1_1();
+      });
+  }
+}
+
+BENCHMARK(BM_T02_uncached)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T03_uncached(benchmark::State& state) { //NOLINT
+  unsigned int seed = time(NULL);
+  set_runtime_pcs(runtime_pcs_libunwind);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < state.range(0); i++) {
+      call_m(rand_r(&seed) % 1);
+    }
+  }
+}
+
+BENCHMARK(BM_T03_uncached)
+->Arg(10*ITERATION)
+->Arg(100*ITERATION)
+->Arg(1000*ITERATION)
+->Arg(10000*ITERATION)
+->Unit(benchmark::kMillisecond);
+
+int main(int argc, char **argv) {
+  printf("Running %s\n", argv[0]);
+  printf("%s", doc);
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/benchmark/bm_tracewinder.cc
+++ b/benchmark/bm_tracewinder.cc
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include "benchmark/bm_common.h"
+
+#include "benchmark/benchmark.h"
+
+static char doc[] =
+  "Benchmark tracewinder.\n"
+  "\n"
+  "BM_T01      : same stack trace\n"
+  "BM_T02      : different stack traces\n"
+  "BM_T03      : randomized\n"
+  "\n"
+  "The test invokes the unwinder function in a loop.\n"
+  "The number of loop iterations are follows the test name.\n"
+  "\n";
+
+static void BM_T01(benchmark::State& state) { //NOLINT
+  while (state.KeepRunning()) {
+    for (int i = 0; i < ITERATION; i++) {
+      l1_1();
+    }
+  }
+}
+
+BENCHMARK(BM_T01)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+
+static void BM_T02(benchmark::State& state) { //NOLINT
+  while (state.KeepRunning()) {
+    faux_unroll<ITERATION>::call([&] {
+        l1_1();
+      });
+  }
+}
+
+BENCHMARK(BM_T02)->Arg(ITERATION)->Unit(benchmark::kMillisecond);
+
+static void BM_T03(benchmark::State& state) { //NOLINT
+  unsigned int seed = time(NULL);
+  while (state.KeepRunning()) {
+    for (int i = 0; i < state.range(0); i++) {
+      call_m(rand_r(&seed) % 1);
+    }
+  }
+}
+
+BENCHMARK(BM_T03)
+->Arg(10*ITERATION)
+->Arg(100*ITERATION)
+->Arg(1000*ITERATION)
+->Arg(10000*ITERATION)
+->Unit(benchmark::kMillisecond);
+
+int main(int argc, char **argv) {
+  printf("Running %s\n", argv[0]);
+  printf("%s", doc);
+
+  Tracewinder *tracewinder;
+  tracewinder = Tracewinder::instance();
+  tracewinder->enable_cache();
+  set_runtime_pcs(tracewinder);
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  return 0;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(hashmap hashmap.c)
+target_link_libraries(hashmap coumap pthread rt)
+
+add_library(runtime_callers runtime_callers_libunwind.cc
+			    runtime_callers_backtrace.cc
+			    runtime_callers_frameptr.cc
+			    runtime_callers_tracewinder.cc)
+set_target_properties(runtime_callers PROPERTIES LINK_FLAGS " libunwind-ptrace.a libunwind.a libunwind-x86_64.a -fno-omit-frame-pointer")
+target_link_libraries(runtime_callers libunwind-ptrace.a libunwind-x86_64.a libunwind.a hashmap)

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef unsigned int uintptr __attribute__ ((mode (pointer)));

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "hashmap.h"
+
+#include "coumap/cmap.h"
+#include "coumap/util.h"
+#include "coumap/hash.h"
+
+typedef struct hashmap {
+  struct cmap cmap;
+  struct cmap_position cmap_position;
+  int (*data_cmp)(void * d1, void * d2);
+  void (*data_free)(void * data);
+} hashmap;
+
+typedef struct hashmap_node {
+  struct cmap_node cmap_node;
+  void * data;
+} hashmap_node;
+
+hashmap * hashmap_init(int (*data_cmp)(void * d1, void * d2), void (*data_free)(void * data)) {
+  hashmap * map = (hashmap *)malloc(sizeof(hashmap));
+  cmap_init(&(map->cmap));
+  map->data_cmp = data_cmp;
+  map->data_free = data_free;
+  return map;
+}
+
+void hashmap_free(hashmap * map) {
+  hashmap_node *node;
+  HASHMAP_FOR_EACH(map, node) {
+    hashmap_node_free(node, map->data_free);
+  }
+  free(map);
+}
+
+hashmap_node * hashmap_node_init(void * data) {
+  hashmap_node * map_node = (hashmap_node *)malloc(sizeof(hashmap_node));
+  map_node->data = data;
+  return map_node;
+}
+
+void hashmap_node_free(hashmap_node * node, void (*data_free)(void * data)) {
+  data_free(node->data);
+}
+
+size_t hashmap_insert(hashmap * map, hashmap_node * node, uint32_t hash) {
+  return cmap_insert(&(map->cmap), &(node->cmap_node), hash);
+}
+
+size_t hashmap_remove(hashmap * map, hashmap_node * node, uint32_t hash) {
+  return cmap_remove(&(map->cmap), &(node->cmap_node), hash);
+}
+
+hashmap_node * hashmap_find(hashmap * map, uint32_t hash, void * data) {
+  hashmap_node * hashmap_node;
+  const struct cmap_node * cmap_node;
+
+  CMAP_FOR_EACH_WITH_HASH(hashmap_node, cmap_node, hash, &(map->cmap)) {
+    if (map->data_cmp(hashmap_node->data, data) == 0) {
+      return hashmap_node;
+    }
+  }
+  return NULL;
+}
+
+size_t hashmap_count(hashmap * map) {
+  return cmap_count(&(map->cmap));
+}
+
+void * hashmap_node_get_data(hashmap_node * node) {
+  return node->data;
+}
+
+void hashmap_foreach_init(hashmap *map) {
+  map->cmap_position.bucket = 0;
+  map->cmap_position.entry = 0;
+  map->cmap_position.offset = 0;
+}
+
+hashmap_node * hashmap_foreach_next(hashmap *map, hashmap_node *node) {
+  struct cmap_node *cmap_node;
+  cmap_node = cmap_next_position(&(map->cmap), &(map->cmap_position));
+  return OBJECT_CONTAINING(cmap_node, node, cmap_node);
+}
+
+uint32_t get_hash_pointer(const void *p, uint32_t basis) {
+  return hash_pointer(p, basis);
+}
+
+uint32_t get_hash_string(const char *c, uint32_t basis) {
+  return hash_string(c, basis);
+}

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct hashmap hashmap;
+typedef struct hashmap_node hashmap_node;
+
+/* Hash map
+ * ===================
+ *
+ */
+
+/*
+ * Returns an initialized hashmap.
+ * data_cmp Function pointer to function for data comparison
+ */
+hashmap * hashmap_init(int (*data_cmp)(void * d1, void * d2), void (*data_free)(void * data));
+void hashmap_free(hashmap * map);
+hashmap_node * hashmap_node_init(void * data);
+void hashmap_node_free(hashmap_node * map_node, void (*data_free)(void * data));
+void * hashmap_node_get_data(hashmap_node * node);
+size_t hashmap_insert(hashmap * map, hashmap_node * node, uint32_t hash);
+size_t hashmap_remove(hashmap * map, hashmap_node * node, uint32_t hash);
+hashmap_node * hashmap_find(hashmap * map, uint32_t hash, void * data);
+
+size_t hashmap_count(hashmap * map);
+
+void hashmap_foreach_init(hashmap *map);
+hashmap_node * hashmap_foreach_next(hashmap *map, hashmap_node *node);
+
+uint32_t get_hash_pointer(const void *p, uint32_t basis);
+uint32_t get_hash_string(const char *c, uint32_t basis);
+
+#define HASHMAP_FOR_EACH(HASHMAP, HASHMAP_NODE)                         \
+  hashmap_foreach_init(HASHMAP);                                        \
+  while ((HASHMAP_NODE = hashmap_foreach_next(HASHMAP, HASHMAP_NODE)))
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/runtime_callers.h
+++ b/src/runtime_callers.h
@@ -1,0 +1,75 @@
+#include "common.h"
+#include "hashmap.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#pragma once
+
+int runtime_pcs_libunwind(uintptr *pcbufs, int buffers);
+int runtime_pcs_libunwind_builtin_cache(uintptr *pcbufs, int buffers);
+
+void flush_libunwind_builtin_cache();
+
+int runtime_pcs_backtrace(uintptr *pcbufs, int buffers);
+int runtime_pcs_frameptr(uintptr *pcbufs, int buffers);
+
+// Haven't found a better solution
+#ifdef __cplusplus
+extern "C" {
+#endif
+  // Map: { Key: IP,
+  //        Value: Delta }
+  // IP identifies the entry point of a function `f()'
+  // Delta is the difference between the `base pointer' of function
+  // `f()' to a generic callee.
+  //
+  // The assumption is that any caller of `f()' will _likely_ place
+  // its `base pointer' at a constant delta in the stack.
+  typedef struct map_node {
+    uintptr ip;
+    int delta;
+  } map_node;
+#ifdef __cplusplus
+}
+#endif
+
+class Tracewinder {
+ public:
+  Tracewinder();
+  ~Tracewinder();
+  static inline Tracewinder* instance() {
+    if (instance_ == NULL)
+      instance_ = new Tracewinder();
+    return instance_;
+  }
+  void enable_cache();
+  void disable_cache();
+  void enable_debug_mode();
+  void disable_debug_mode();
+  int runtime_pcs_tracewinder(uintptr *pcbufs,
+                              int buffers);
+ private:
+  size_t plum_unwind_stack__(const uintptr pc,
+                             const uintptr bp,
+                             const uintptr stack_top,
+                             const uintptr stack_bottom,
+                             uintptr *trace_buffer,
+                             const size_t max_depth);
+  // Thou shalt have no other tracewinder before me.
+  static Tracewinder *instance_;
+  // Caching Map {Key: IP, Value: Delta}
+  hashmap * stack_unwind_map_;
+  // Just for internal usage
+  map_node lookup_node_;
+
+  uint64_t activity_counter_;
+  uint32_t ip_offset_;
+  uint32_t frame_skip_;
+  // Caching related stuff
+  bool cache_enable_;
+  uint64_t cache_hit_cnt_;
+  uint64_t cache_miss_cnt_;
+  // Debug mode
+  bool debug_mode_;
+};

--- a/src/runtime_callers_backtrace.cc
+++ b/src/runtime_callers_backtrace.cc
@@ -1,0 +1,9 @@
+#include "runtime_callers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <execinfo.h>
+
+int runtime_pcs_backtrace(uintptr *pcbufs,  int buffers) {
+  return backtrace((void **)pcbufs, buffers);
+}

--- a/src/runtime_callers_frameptr.cc
+++ b/src/runtime_callers_frameptr.cc
@@ -1,0 +1,83 @@
+#include "runtime_callers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+unwind_is_valid_frame__(const uintptr frame, const uintptr stack_top, const uintptr stack_bottom) {
+  return (frame > stack_bottom) && (frame < stack_top - 2 * sizeof (uintptr));
+}
+
+int
+unwind_is_aligned__(const uintptr ptr, const uintptr alignment) {
+#ifdef USE_FIBER
+  return (ptr & (alignment - 1)) == 0;
+#else
+  return (ptr & (alignment)) == 0;
+#endif
+}
+
+size_t
+fast_unwind_stack__(int frame_skip,
+                    const uintptr pc, const uintptr bp,
+                    const uintptr stack_top, const uintptr stack_bottom,
+                    uintptr *trace_buffer, const size_t max_depth) {
+  const uintptr kPageSize = 0x1000;
+
+  // skip the first PC for compatibility with the visualization used by the fiber subsystem
+  size_t size = 0;
+  int cnt = 0;
+
+  if (stack_top < 4096)
+    // Sanity check for stack top.
+    return size;
+
+  // interpret bp as an address, so we can access the value at its
+  // location (the BP of the caller, saved by the prologue of the
+  // callee) and the value at bp + 8, that is the pc the callee will return to
+  // (i.e. the next instruction to be executed in the caller function)
+  uintptr *frame = (uintptr *)bp;
+  // Lowest possible address that makes sense as the next frame pointer.
+  // Goes up as we walk the stack.
+  uintptr bottom = stack_bottom;
+  // Avoid infinite loop when frame == frame[0] by using frame > prev_frame.
+  while (unwind_is_valid_frame__((uintptr)frame, stack_top, bottom) &&
+         unwind_is_aligned__((uintptr)frame, sizeof(*frame)) &&
+         size < max_depth) {
+    uintptr pc1 = frame[1];
+    // Let's assume that any pointer in the 0th page (i.e. <0x1000 on i386 and
+    // x86_64) is invalid and stop unwinding here.
+    if (pc1 < kPageSize)
+      break;
+
+    // store the PC we have just fetched; the '-1' decrement is needed
+    // for compatibility with the fiber library, that expect a ptr to last
+    // insn executed in the caller, not the return address
+    if (cnt >= frame_skip)
+#ifdef USE_FIBER
+      trace_buffer[size++] = pc1 - 1;
+#else
+      trace_buffer[size++] = pc1;
+#endif
+    cnt++;
+
+    bottom = (uintptr) frame;
+    frame = (uintptr *) frame[0];
+  }
+
+  return size;
+}
+
+size_t runtime_callers_frameptr(size_t skip, uintptr *pcbuf, size_t m) {
+  return fast_unwind_stack__(skip,
+                             (uintptr) __builtin_return_address(1), // pc
+                             (uintptr) __builtin_frame_address(1), // bp
+                             0xffffffffffff,  // stack top (highest address)
+                             0x0, // stack bottom (lowest address)
+                             pcbuf, m);
+}
+
+
+int runtime_pcs_frameptr(uintptr *pcbufs, int buffers) {
+  return runtime_callers_frameptr (1, pcbufs, buffers);
+}

--- a/src/runtime_callers_libunwind.cc
+++ b/src/runtime_callers_libunwind.cc
@@ -1,0 +1,56 @@
+#include "runtime_callers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <libunwind.h>
+
+int runtime_pcs_libunwind(uintptr *pcbufs, int buffers) {
+  unw_cursor_t cursor;
+  unw_context_t uc;
+  unw_word_t ip;
+  int i = 0;
+  int cnt = 0;
+  int frame_skip = 1;
+
+  unw_getcontext(&uc);
+  unw_init_local(&cursor, &uc);
+  if (unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_NONE)) {
+    fprintf(stderr, "Unable to set libunwind policy.\n");
+    exit(-1);
+  }
+  while (unw_step(&cursor) > 0 && i < buffers) {
+    unw_get_reg(&cursor, UNW_REG_IP, &ip);
+    if (cnt >= frame_skip)
+      pcbufs[i++] = ip;
+    cnt++;
+  }
+  return i;
+}
+
+/* libunwind */
+int runtime_pcs_libunwind_builtin_cache(uintptr *pcbufs, int buffers) {
+  unw_cursor_t cursor;
+  unw_context_t uc;
+  unw_word_t ip;
+  int i = 0;
+  int cnt = 0;
+  int frame_skip = 1;
+
+  unw_getcontext(&uc);
+  unw_init_local(&cursor, &uc);
+  if (unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_GLOBAL)) {
+    fprintf(stderr, "Unable to set libunwind policy.\n");
+    exit(-1);
+  }
+  while (unw_step(&cursor) > 0 && i < buffers) {
+    unw_get_reg(&cursor, UNW_REG_IP, &ip);
+    if (cnt >= frame_skip)
+      pcbufs[i++] = ip;
+    cnt++;
+  }
+  return i;
+}
+
+void flush_libunwind_builtin_cache() {
+  unw_flush_cache(unw_local_addr_space, 0, 0);
+}

--- a/src/runtime_callers_tracewinder.cc
+++ b/src/runtime_callers_tracewinder.cc
@@ -1,0 +1,251 @@
+#include "runtime_callers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <libunwind.h>
+
+void  map_node_free(void *node) {
+  free(node);
+}
+
+int map_node_cmp(void *a, void *b) {
+  // printf("Comparing 0x%lx with 0x%lx\n",
+  //     ((map_node *)a)->ip,
+  //     ((map_node *)b)->ip);
+  return ((map_node *)a)->ip - ((map_node *)b)->ip;
+}
+
+Tracewinder* Tracewinder::instance_ = NULL;
+
+Tracewinder::Tracewinder()
+  : activity_counter_(0),
+    ip_offset_(0),
+    frame_skip_(2),
+    cache_hit_cnt_(0),
+    cache_miss_cnt_(0),
+    debug_mode_(false) {
+
+  // enable libunwind builtin cache
+  if (unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_NONE)) {
+    fprintf(stderr, "Unable to set libunwind policy.\n");
+    exit(-1);
+  }
+  // enable tracewinder cache as well
+  enable_cache();
+  // initialize the cache map
+  stack_unwind_map_ = hashmap_init(map_node_cmp, map_node_free);
+}
+
+Tracewinder::~Tracewinder() { }
+
+void Tracewinder::enable_cache() {
+  cache_enable_ = true;
+}
+void Tracewinder::disable_cache() {
+  cache_enable_ = false;
+}
+
+void Tracewinder::enable_debug_mode() {
+  debug_mode_ = true;
+}
+void Tracewinder::disable_debug_mode() {
+  debug_mode_ = false;
+}
+
+size_t Tracewinder::plum_unwind_stack__(const uintptr ip, const uintptr sp,
+                                       const uintptr stack_top, const uintptr stack_bottom,
+                                       uintptr *trace_buffer, const size_t max_depth) {
+
+  struct map_node * map_node;
+  hashmap_node * hashmap_node;
+
+  uint32_t cnt = 0;
+  /* Lookup in the Cache */
+  if (cache_enable_) {
+      // First check in local cache to see if the stack can be
+      // unwound. this will abort Even if one layer fails.
+      uintptr cur_ip = ((uintptr)ip + ip_offset_);
+      uintptr cur_sp = (uintptr)sp;
+      bool found = false;
+      while (true) {
+        lookup_node_.ip = cur_ip;
+        hashmap_node = hashmap_find(stack_unwind_map_,
+                                    get_hash_pointer((const void *)cur_ip, 0),
+                                    &lookup_node_);
+        if (hashmap_node == NULL) {
+          break;
+        } else {
+          // lookup succeded, we already recorded this IP
+          map_node = (struct map_node *)hashmap_node_get_data(hashmap_node);
+
+          if (cnt >= frame_skip_) {
+            trace_buffer[cnt - frame_skip_] = (uint64_t)cur_ip;
+          }
+          ++cnt;
+
+          // check for terminating call-stack terminator (delta == 0)
+          if (map_node->delta == 0) {
+            found = true;
+            break;
+          }
+          // Here we should do more checking.
+          // What if we got a wrong delta?
+          // ip_ptr would point somewhere in the stack. Doing so may
+          // crash the program.
+          uint64_t* ip_ptr = (uint64_t *)(cur_sp + map_node->delta - 8);
+          if (ip_ptr == 0) {
+            found = true;
+            break;
+          }
+#ifdef USE_FIBER
+          cur_ip = (uintptr)(*ip_ptr - 1);
+#else
+          cur_ip = (uintptr)*ip_ptr;
+#endif
+          cur_sp = cur_sp + map_node->delta;
+        }
+      }
+      if (found) {
+        cache_hit_cnt_++;
+        return (cnt - frame_skip_);
+      }
+  }
+
+  /* Cache Miss
+   * Let's unwind using DWARF symbols
+   */
+  unw_cursor_t cursor;
+  unw_context_t uc;
+  unw_word_t unwind_ip, unwind_sp;
+  unw_word_t prev_sp = 0, prev_ip;
+  int delta = 0;
+
+  cnt = 0;
+  cache_miss_cnt_++;
+  unw_getcontext(&uc);
+  unw_init_local(&cursor, &uc);
+
+  while (unw_step(&cursor) > 0) {
+    // Get IP and SP of the given call stack
+    unw_get_reg(&cursor, UNW_REG_IP, &unwind_ip);
+    unw_get_reg(&cursor, UNW_REG_SP, &unwind_sp);
+
+    // Compute the IP offset if not already done
+    // The IP offset should always be constant
+#ifdef USE_FIBER
+    if (!ip_offset_) {
+      ip_offset_ = (uint32_t)unwind_ip - 1 - (uint32_t)ip;
+    } else if (!cnt  && (uint32_t)ip_offset_ != ((uint32_t)unwind_ip - 1 - (uint32_t)ip)) {
+      fprintf(stderr, "ERROR - Detected a change in ip offset %d %ld\n",
+              ip_offset_, ((uint32_t)unwind_ip - (uint32_t)ip));
+      ip_offset_ = (uint32_t)unwind_ip - 1 - (uint32_t)ip;
+    }
+#else
+    if (!ip_offset_) {
+      ip_offset_ = (uint32_t)unwind_ip - (uint32_t)ip;
+    } else if (!cnt  && (uint32_t)ip_offset_ != ((uint32_t)unwind_ip - (uint32_t)ip)) {
+      fprintf(stderr, "ERROR - Detected a change in ip offset %d %u\n",
+              ip_offset_, ((uint32_t)unwind_ip - (uint32_t)ip));
+      ip_offset_ = (uint32_t)unwind_ip - (uint32_t)ip;
+    }
+#endif
+
+#ifdef USE_FIBER
+    // adjust ip for signal code.
+    int ip_before_insn = 0;
+    ip_before_insn = unw_is_signal_frame(&cursor);
+    if (!ip_before_insn)
+      --unwind_ip;
+#endif
+
+    // Cache it
+    // Skip the first iteration, as we cache f<n> at the f<n-1>
+    // iteration
+    if (cache_enable_ && prev_sp) {
+      delta = unwind_sp - prev_sp;
+
+      // Let's lookup in the map
+      lookup_node_.ip = prev_ip;
+      hashmap_node = hashmap_find(stack_unwind_map_,
+                                  get_hash_pointer((const void *)prev_ip, 0),
+                                  &lookup_node_);
+      if (hashmap_node == NULL) {
+        // lookup failed, let's insert the new record in the map
+        map_node = (struct map_node *)malloc(sizeof(struct map_node));
+        map_node->ip = prev_ip;
+        map_node->delta = delta;
+        hashmap_node = hashmap_node_init(map_node);
+        hashmap_insert(stack_unwind_map_,
+                       hashmap_node,
+                       get_hash_pointer((const void *)prev_ip, 0));
+      } else {
+        // lookup succeded, we already recorded this IP
+        map_node = (struct map_node *)hashmap_node_get_data(hashmap_node);
+        if ((uint32_t)map_node->delta != (uint32_t)delta) {
+          if (map_node->delta) {
+            fprintf(stderr, "Delta change mismatch {ip=%lx : delta=%d}.\n"
+                    "New recorded delta = %d\n",
+                    prev_ip, map_node->delta, delta);
+          }
+          // delta was 0, update it with the new value
+          map_node->delta = delta;
+        }
+      }
+    }
+
+
+    if (cnt >= frame_skip_)
+      trace_buffer[cnt - frame_skip_] = (uint64_t) unwind_ip;
+    cnt++;
+
+    if (cnt >= (max_depth + frame_skip_))
+      break;
+
+    // Update IP and SP
+    prev_ip = unwind_ip;
+    prev_sp = unwind_sp;
+  }
+
+  // The delta for the last entry of the stack chain is arbitrary set to 0
+  if (cache_enable_) {
+    lookup_node_.ip = prev_ip;
+    hashmap_node = hashmap_find(stack_unwind_map_,
+                                get_hash_pointer((const void *)prev_ip, 0),
+                                &lookup_node_);
+    if (hashmap_node == NULL) {
+      map_node = (struct map_node *)malloc(sizeof(struct map_node));
+      map_node->ip = prev_ip;
+      map_node->delta = 0;
+      hashmap_node = hashmap_node_init(map_node);
+      hashmap_insert(stack_unwind_map_,
+                     hashmap_node,
+                     get_hash_pointer((const void *)prev_ip, 0));
+    } else {
+      map_node = (struct map_node *)hashmap_node_get_data(hashmap_node);
+      map_node->delta = 0;
+    }
+  }
+
+  /*
+   * WARNING: *debug_mode*
+   * In debug_mode, we will add this extra check.  We will print out
+   * if the caching routine produces a different result than the
+   * DWARF-unwinder.
+   * In case you use debug_mode, you will get worst performance than
+   * with a DWARF-unwinder only solution.
+   */
+
+  // ...
+
+  return (cnt - frame_skip_);
+}
+
+int Tracewinder::runtime_pcs_tracewinder(uintptr *pcbufs, int buffers) {
+  register void* sp asm("sp");
+ selflabel:
+  return plum_unwind_stack__((uintptr)&&selflabel,
+                             (uintptr)sp,
+                             0xffffffffffff,  // stack top (highest address)
+                             0x0, // stack bottom (lowest address)
+                             pcbufs, buffers);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,9 @@
+find_package(GTest REQUIRED)
+
+add_executable(test_tracewinder test_tracewinder.cc)
+target_link_libraries(test_tracewinder runtime_callers benchmark pthread ${GTEST_LIBRARIES})
+add_test(test_tracewinder ${CMAKE_CURRENT_BINARY_DIR}/test_tracewinder)
+
+add_executable(test_common test_common.cc)
+target_link_libraries(test_common runtime_callers benchmark pthread ${GTEST_LIBRARIES})
+add_test(test_common ${CMAKE_CURRENT_BINARY_DIR}/test_common)

--- a/test/test_common.cc
+++ b/test/test_common.cc
@@ -1,0 +1,81 @@
+#include "test_common.h"
+
+#include <gtest/gtest.h>
+
+void runtime_error_dump(uintptr pcbuf[100][100], int * pcbuf_n,
+                         uint32_t *idx) {
+  for (uint32_t i = 0; i < 2; i++) {
+    fprintf(stdout, "pcbuf with idx %u has %d reported pcs\n", idx[i], pcbuf_n[idx[i]]);
+    for (uint32_t j = 0; j < (uint32_t)pcbuf_n[idx[i]]; j++) {
+      fprintf(stdout, "pc %lx\n", pcbuf[idx[i]][j]);
+    }
+  }
+}
+
+int test_runtime_pcs() {
+  Tracewinder *p;
+  p = Tracewinder::instance();
+  p->enable_cache();
+  p->enable_debug_mode();
+
+  uint32_t i, j, k;
+  runtime_pcs r[] = {
+    runtime_pcs_libunwind,
+    runtime_pcs_libunwind_builtin_cache,
+    // runtime_pcs_backtrace
+    // runtime_pcs_frameptr
+  };
+  const uint32_t N = (sizeof r / sizeof r[0]) + 1;
+  uintptr pcbuf[N][100];
+  int pcbuf_n[N];
+
+  // Test all runtime_pcs functions
+  for (i = 0; i < N - 1; i++) {
+    pcbuf_n[i] = r[i](pcbuf[i], sizeof pcbuf[i] / sizeof pcbuf[i][0]);
+  }
+  // Call pcs_tracewinder
+  pcbuf_n[i] = p->runtime_pcs_tracewinder(pcbuf[i],
+                                         sizeof pcbuf[i] / sizeof pcbuf[i][0]);
+
+  // Compare results
+  for (i = 0; i < N; i++) {
+    for (j = 0; j < N; j++) {
+      // Get only the upper triangular part of the matrix
+      if (i > j) {
+        // reported the same number of pcs
+        if (pcbuf_n[i] == pcbuf_n[j]) {
+          for (k = 0; k < (uint32_t)pcbuf_n[i]; k++) {
+            if (pcbuf[i][k] != pcbuf[j][k]) {
+              fprintf(stderr, "Error: pc mismatch between runtime_pcs function.\n");
+              fprintf(stderr, "       runtime_pcs func %d reported %lx.\n", i, pcbuf[i][k]);
+              fprintf(stderr, "       runtime_pcs func %d reported %lx.\n", j, pcbuf[j][k]);
+              uint32_t idx[2] = {i, j};
+              runtime_error_dump(pcbuf, pcbuf_n, idx);
+              return -1;
+            }
+          }
+        } else {
+          fprintf(stderr, "Error: mismatch between reported number of pcs.\n");
+          fprintf(stderr, "       runtime_pcs func %d reported %d.\n", i, pcbuf_n[i]);
+          fprintf(stderr, "       runtime_pcs func %d reported %d.\n", j, pcbuf_n[j]);
+          uint32_t idx[2] = {i, j};
+          runtime_error_dump(pcbuf, pcbuf_n, idx);
+          return -1;
+        }
+      }
+    }
+  }
+  return 0;
+}
+
+TEST(TestCommon, basic) {
+  for (int i = 0; i < 100; i++) {
+    ASSERT_EQ(test_runtime_pcs(), 0);
+  }
+}
+
+int main(int ac, char ** av) {
+  printf("Running %s\n", av[0]);
+  testing::InitGoogleTest(&ac, av);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include "common.h"
+#include "runtime_callers.h" // for current_runtime_pcs initialization
+
+#pragma once
+
+#define NOINLINE       __attribute__((noinline))
+
+typedef int (*runtime_pcs)(uintptr *, int);

--- a/test/test_tracewinder.cc
+++ b/test/test_tracewinder.cc
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "runtime_callers.h"
+
+#include <gtest/gtest.h>
+
+void basic_test() {
+  // Get the tracewinder
+  Tracewinder *p;
+  p = Tracewinder::instance();
+  // Enable cache
+  p->enable_cache();
+  p->enable_debug_mode();
+
+  uintptr pcbuf1[100];
+  uintptr pcbuf2[100];
+  int n1, n2;
+
+  n1 = p->runtime_pcs_tracewinder(pcbuf1, sizeof pcbuf1 / sizeof pcbuf1[0]);
+  n2 = runtime_pcs_libunwind(pcbuf2, sizeof pcbuf2 / sizeof pcbuf2[0]);
+
+  ASSERT_EQ(n1, n2);
+
+  for (int i = 0; i < n1; i++) {
+    ASSERT_EQ(pcbuf1[i], pcbuf2[i]);
+  }
+}
+
+TEST(TestTracewinder, basic) {
+  for (int i = 0; i < 100; i++) {
+    basic_test();
+  }
+}
+
+int main(int ac, char ** av) {
+  printf("Running %s\n", av[0]);
+  testing::InitGoogleTest(&ac, av);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Unwinders added:
- libunwind
- backtrace
- frameptr (relying on code strictly compiled frame pointer)
- tracewinder (custom algorithm based on stack delta caching)

Unit tests are not complete. Their main purpose in this commit is to
test the tracewinder.

Benchmarks show that tracewinder is actually 1 order of magnitute
faster then traditional DWARF-based unwinders.

Adding Travis-CI support as well.

Signed-off-by: Lorenzo David lorenzod@plumgrid.com
